### PR TITLE
New rule: arrow-body-style

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ This config starts from [`eslint:recommended`][1] then adds the following rules:
 | Rule | Config | Principles/rationale |
 |------|--------|----------------------|
 | [arrow-parens] | | 2, 3 |
+| [arrow-body-style] | `"always"` | 2 |
 | [brace-style] | `"1tbs", { "allowSingleLine": false }` | |
 | [comma-dangle] | `"always-multiline"` | 3 |
 | [curly] | | 2 |
@@ -51,6 +52,7 @@ This config starts from [`eslint:recommended`][1] then adds the following rules:
   [1]: https://eslint.org/docs/user-guide/configuring#using-eslintrecommended
   [2]: https://www.reddit.com/r/javascript/comments/c8drjo/nobody_talks_about_the_real_reason_to_use_tabs/
 
+  [arrow-body-style]: https://eslint.org/docs/rules/arrow-body-style
   [arrow-parens]: https://eslint.org/docs/rules/arrow-parens
   [ASI rules]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#Automatic_semicolon_insertion
   [brace-style]: https://eslint.org/docs/rules/brace-style

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@
 module.exports = {
 	extends: ["eslint:recommended"],
 	rules: {
+		"arrow-body-style": ["error", "always"],
 		"arrow-parens": "error",
 		"brace-style": ["error", "1tbs", { "allowSingleLine": false }],
 		"comma-dangle": ["error", "always-multiline"],


### PR DESCRIPTION
Arrow functions that just return a value have two options:

 1. `() => value`; or
 2. `() => { return value; }`.

If they do anything other than just return, the braces are not optional. Therefore, in line with principle 2, perhaps we should always encourage the second option.