### PR TITLE
Rule config change: make quotes configuration compatible with Prettier

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ This config starts from [`eslint:recommended`][1] then adds the following rules:
 | standard, lax | [no-var] | | Stick with `let` and `const` for more predictable behaviour |
 | standard, lax | [object-curly-spacing] | `"always"` | |
 | standard, lax | [operator-linebreak] | `"before"` | |
-| standard, lax | [quotes] | `"double"` | More likely to need `'` inside a string than `"` |
+| standard, lax | [quotes] | `"double", { "avoidEscape": true, "allowTemplateLiterals": false }` | More likely to need `'` inside a string than `"` |
 | standard, lax | [semi] | | Students shouldn't have to memorise the [ASI rules] |
 
 ## Development

--- a/lax.js
+++ b/lax.js
@@ -12,7 +12,7 @@ module.exports = {
 		"no-var": "error",
 		"object-curly-spacing": ["error", "always"],
 		"operator-linebreak": ["error", "before"],
-		"quotes": ["error", "double"],
+		"quotes": ["error", "double", { "avoidEscape": true, "allowTemplateLiterals": false }],
 		"semi": "error",
 	},
 };


### PR DESCRIPTION
Changes the configuration of the `quotes` rule so that it doesn't conflict with what Prettier does (per https://github.com/prettier/eslint-config-prettier/#quotes, see #12). This is a **breaking change** because unnecessary backticks around strings that don't contain interpolation are now forbidden:

```diff
-const no = `foo`;
+const no = "foo";
 const yes = `this ${no}`;
```

-----
[View rendered README.md](https://github.com/CodeYourFuture/eslint-config-standard/blob/prettier-quotes/README.md)