### PR TITLE
Upgrade to support ESLint v9 "flat" configuration

### DIFF
--- a/.eslintrc.root
+++ b/.eslintrc.root
@@ -1,7 +1,0 @@
-{
-  "env": {
-    "es6": true,
-    "node": true
-  },
-  "extends": "."
-}

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -30,7 +30,7 @@ jobs:
     needs: build
     strategy:
       matrix:
-        eslint: [6, 7, 8, 9]
+        eslint: [8.27, 8, 9]
         node: [16, 18, 20]
         exclude:
           # ESLint v9 requires Node ^18.18.0 || ^20.9.0 || >=21.1.0
@@ -56,7 +56,7 @@ jobs:
     needs: build
     strategy:
       matrix:
-        eslint: [8, 9]
+        eslint: [8.27, 8, 9]
         node: [16, 18, 20]
         exclude:
           # ESLint v9 requires Node ^18.18.0 || ^20.9.0 || >=21.1.0

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -51,10 +51,36 @@ jobs:
         ESLINT_USE_FLAT_CONFIG: 'false'
         ESLINT_VERSION: ${{ matrix.eslint }}
         PACK: 'false'
+  test-flat-config:
+    runs-on: ubuntu-22.04
+    needs: build
+    strategy:
+      matrix:
+        eslint: [8, 9]
+        node: [16, 18, 20]
+        exclude:
+          # ESLint v9 requires Node ^18.18.0 || ^20.9.0 || >=21.1.0
+          - eslint: 9
+            node: 16
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          cache: 'npm'
+          node-version: ${{ matrix.node }}
+      - uses: actions/download-artifact@v4
+        with:
+          name: package
+      - run: npm ci
+      - run: npm run test:install
+        env:
+          ESLINT_USE_FLAT_CONFIG: 'true'
+          ESLINT_VERSION: ${{ matrix.eslint }}
+          PACK: 'false'
   deploy-github:
     runs-on: ubuntu-22.04
     if: startsWith(github.ref, 'refs/tags/v')
-    needs: test-eslintrc
+    needs: [test-eslintrc, test-flat-config]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
@@ -70,7 +96,7 @@ jobs:
   deploy-npm:
     runs-on: ubuntu-22.04
     if: startsWith(github.ref, 'refs/tags/v')
-    needs: test-eslintrc
+    needs: [test-eslintrc, test-flat-config]
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-node@v4

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -25,13 +25,17 @@ jobs:
         if-no-files-found: error
         name: package
         path: codeyourfuture-eslint-config-standard-*.tgz
-  install:
+  test-eslintrc:
     runs-on: ubuntu-22.04
     needs: build
     strategy:
       matrix:
-        eslint: [6, 7, 8]
+        eslint: [6, 7, 8, 9]
         node: [16, 18, 20]
+        exclude:
+          # ESLint v9 requires Node ^18.18.0 || ^20.9.0 || >=21.1.0
+          - eslint: 9
+            node: 16
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-node@v4
@@ -44,12 +48,13 @@ jobs:
     - run: npm ci
     - run: npm run test:install
       env:
+        ESLINT_USE_FLAT_CONFIG: 'false'
         ESLINT_VERSION: ${{ matrix.eslint }}
         PACK: 'false'
   deploy-github:
     runs-on: ubuntu-22.04
     if: startsWith(github.ref, 'refs/tags/v')
-    needs: install
+    needs: test-eslintrc
     steps:
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
@@ -65,7 +70,7 @@ jobs:
   deploy-npm:
     runs-on: ubuntu-22.04
     if: startsWith(github.ref, 'refs/tags/v')
-    needs: install
+    needs: test-eslintrc
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-node@v4

--- a/README.md
+++ b/README.md
@@ -30,15 +30,33 @@ Install this package along with ESLint itself:
 npm install --save-dev eslint @codeyourfuture/eslint-config-standard
 ```
 
-Then create an [ESLint config file] and add this config to the `"extends"` section:
+Then create an [ESLint config file] and add this config:
+
+```javascript
+const cyfConfig = require("@codeyourfuture/eslint-config-standard");
+
+module.exports = [cyfConfig];
+```
+
+or using ES module syntax:
+
+```javascript
+import cyfConfig from "@codeyourfuture/eslint-config-standard";
+
+export default [cyfConfig];
+```
+
+Alternatively, for a slightly more permissive set of rules, you can use `@codeyourfuture/eslint-config-standard/lax`.
+
+### `.eslintrc`
+
+If you have not yet migrated to the newer ESLint "flat config", you can apply these rules to the [deprecated config] using `"extends"`:
 
 ```json
 {
   "extends": ["@codeyourfuture/standard"]
 }
 ```
-
-Alternatively, for a slightly more permissive set of rules, you can extend `@codeyourfuture/eslint-config-standard/lax`.
 
 ## Principles
 
@@ -89,7 +107,8 @@ You can clone this repo and run `npm install` to install the development depende
   [brace-style]: https://eslint.org/docs/rules/brace-style
   [comma-dangle]: https://eslint.org/docs/rules/comma-dangle
   [curly]: https://eslint.org/docs/rules/curly
-  [ESLint config file]: https://eslint.org/docs/user-guide/configuring
+  [deprecated config]: https://eslint.org/docs/latest/use/configure/configuration-files-deprecated
+  [ESLint config file]: https://eslint.org/docs/latest/use/configure/configuration-files
   [indent]: https://eslint.org/docs/rules/indent
   [linebreak-style]: https://eslint.org/docs/rules/linebreak-style
   [no-trailing-spaces]: https://eslint.org/docs/rules/no-trailing-spaces

--- a/README.md
+++ b/README.md
@@ -60,9 +60,9 @@ If you have not yet migrated to the newer ESLint "flat config", you can apply th
 
 ## Principles
 
- 1. **Errors only** - don't train students to ignore *any* output, all rules should either be `"error"` or `"off"`
+ 1. **Errors only** - don't teach trainees to ignore *any* output, all rules should either be `"error"` or `"off"`
  2. **Maximise consistency** - where there are options (e.g. braces for single-line statements, parentheses around arrow function parameters), be consistent with the non-optional cases
- 3. **Minimise change set size** - keep commits small so students can focus on the important changes
+ 3. **Minimise change set size** - keep commits small so trainees can focus on the important changes
 
 ## Rules
 
@@ -82,7 +82,7 @@ This config starts from [`eslint:recommended`][1] then adds the following rules:
 | standard, lax | [object-curly-spacing] | `"always"` | |
 | standard, lax | [operator-linebreak] | `"before"` | |
 | standard, lax | [quotes] | `"double", { "avoidEscape": true, "allowTemplateLiterals": false }` | More likely to need `'` inside a string than `"` |
-| standard, lax | [semi] | | Students shouldn't have to memorise the [ASI rules] |
+| standard, lax | [semi] | | Trainees shouldn't have to memorise the [ASI rules] |
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ If you have not yet migrated to the newer ESLint "flat config", you can apply th
 
 ## Rules
 
-This config starts from [`eslint:recommended`][1] then adds the following rules:
+This config starts from [`js.configs.recommended`][1] then adds the following rules:
 
 | Configuration| Rule | Setting | Principles/rationale |
 |---|---|---|---|
@@ -99,7 +99,7 @@ You can clone this repo and run `npm install` to install the development depende
     no version conflicts and lints `index.js`. E.g. `ESLINT_VERSION=6 npm run test` will test that this configuration
     works with the latest version of ESLint 6.
 
-  [1]: https://eslint.org/docs/user-guide/configuring#using-eslintrecommended
+  [1]: https://eslint.org/docs/latest/use/configure/configuration-files#using-predefined-configurations
   [2]: https://www.reddit.com/r/javascript/comments/c8drjo/nobody_talks_about_the_real_reason_to_use_tabs/
 
   [arrow-parens]: https://eslint.org/docs/rules/arrow-parens

--- a/bin/examples.sh
+++ b/bin/examples.sh
@@ -2,20 +2,23 @@
 set -uo pipefail
 
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-EXAMPLES="$HERE/../examples"
-ESLINT="$HERE/../node_modules/.bin/eslint"
+EXAMPLES="$(cd "$HERE/../examples" && pwd)"
+ESLINT="$(cd "$HERE/../node_modules/.bin" && pwd)/eslint"
 
 for DIR in $EXAMPLES/*; do
-  echo "checking $DIR"
+  FLAT="$([[ -f "$DIR/eslint.config.js" ]] && echo 'true' || echo 'false')"
+  CONFIG="$DIR/$([[ "$FLAT" = 'true' ]] && echo 'eslint.config.js' || echo '.eslintrc')"
 
-  if "$ESLINT" "$DIR/pass.js"; then
+  echo "checking $DIR (flat=$FLAT)"
+
+  if ESLINT_USE_FLAT_CONFIG="$FLAT" "$ESLINT" --config "$CONFIG" "$DIR/pass.js"; then
     echo "$DIR pass.js success"
   else
     echo "$DIR pass.js failure"
     exit 1
   fi
 
-  if "$ESLINT" "$DIR/fail.js"; then
+  if ESLINT_USE_FLAT_CONFIG="$FLAT" "$ESLINT" --config "$CONFIG" "$DIR/fail.js"; then
     echo "$DIR fail.js failure"
     exit 1
   else

--- a/eslint.root.js
+++ b/eslint.root.js
@@ -1,0 +1,19 @@
+const { node } = require("globals");
+
+const cyfConfig = require(".");
+
+/** @type {import("eslint").Linter.FlatConfig} */
+module.exports = [
+	{
+		languageOptions: {
+			ecmaVersion: 9,
+			globals: node,
+		},
+	},
+	cyfConfig,
+	{
+		rules: {
+			"quote-props": ["error", "consistent-as-needed"],
+		},
+	},
+];

--- a/examples/.eslintrc
+++ b/examples/.eslintrc
@@ -1,6 +1,0 @@
-{
-  "env": {
-    "es6": true,
-    "node": true
-  }
-}

--- a/examples/flat/eslint.config.js
+++ b/examples/flat/eslint.config.js
@@ -1,0 +1,14 @@
+const { node } = require("globals");
+
+const cyfConfig = require("../..");
+
+/** @type {import("eslint").Linter.FlatConfig} */
+module.exports = [
+  {
+    languageOptions: {
+      ecmaVersion: 9,
+      globals: node,
+    },
+  },
+  cyfConfig,
+];

--- a/examples/flat/fail.js
+++ b/examples/flat/fail.js
@@ -1,0 +1,3 @@
+var thing = {
+  foo: 123
+}

--- a/examples/flat/pass.js
+++ b/examples/flat/pass.js
@@ -1,0 +1,5 @@
+const thing = {
+	foo: 123,
+};
+
+console.log(thing);

--- a/examples/lax/.eslintrc
+++ b/examples/lax/.eslintrc
@@ -3,5 +3,6 @@
     "es6": true,
     "node": true
   },
-  "extends": "../../lax"
+  "extends": "../../lax",
+  "root": true
 }

--- a/examples/lax/.eslintrc
+++ b/examples/lax/.eslintrc
@@ -1,3 +1,7 @@
 {
+  "env": {
+    "es6": true,
+    "node": true
+  },
   "extends": "../../lax"
 }

--- a/examples/standard/.eslintrc
+++ b/examples/standard/.eslintrc
@@ -1,3 +1,7 @@
 {
+  "env": {
+    "es6": true,
+    "node": true
+  },
   "extends": "../../."
 }

--- a/examples/standard/.eslintrc
+++ b/examples/standard/.eslintrc
@@ -3,5 +3,6 @@
     "es6": true,
     "node": true
   },
-  "extends": "../../."
+  "extends": "../../.",
+  "root": true
 }

--- a/index.js
+++ b/index.js
@@ -1,9 +1,10 @@
 "use strict";
+const lax = require("./lax");
 
 module.exports = {
-	extends: ["./lax"],
 	rules: {
-		"indent": ["error", "tab", { "SwitchCase": 1 }],
+		...lax.rules,
+		"indent": ["error", "tab", { SwitchCase: 1 }],
 		"linebreak-style": ["error", "unix"],
 	},
 };

--- a/lax.js
+++ b/lax.js
@@ -1,18 +1,19 @@
 "use strict";
+const { configs: { recommended } } = require("@eslint/js");
 
 module.exports = {
-	extends: ["eslint:recommended"],
 	rules: {
+		...recommended.rules,
 		"arrow-parens": "error",
-		"brace-style": ["error", "1tbs", { "allowSingleLine": false }],
+		"brace-style": ["error", "1tbs", { allowSingleLine: false }],
 		"comma-dangle": ["error", "always-multiline"],
 		"curly": "error",
 		"no-trailing-spaces": "error",
-		"no-unused-vars": ["error", { "ignoreRestSiblings": true }],
+		"no-unused-vars": ["error", { ignoreRestSiblings: true }],
 		"no-var": "error",
 		"object-curly-spacing": ["error", "always"],
 		"operator-linebreak": ["error", "before"],
-		"quotes": ["error", "double", { "avoidEscape": true, "allowTemplateLiterals": false }],
+		"quotes": ["error", "double", { avoidEscape: true, allowTemplateLiterals: false }],
 		"semi": "error",
 	},
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,13 +9,13 @@
       "version": "4.0.3",
       "license": "ISC",
       "devDependencies": {
-        "eslint": "^8.44.0"
+        "eslint": "^9.1.1"
       },
       "funding": {
         "url": "https://github.com/sponsors/CodeYourFuture"
       },
       "peerDependencies": {
-        "eslint": "^6 || ^7 || ^8"
+        "eslint": "^8.27 || ^9"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -43,24 +43,24 @@
       }
     },
     "node_modules/@eslint-community/regexpp": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.5.1.tgz",
-      "integrity": "sha512-Z5ba73P98O1KUYCCJTUeVpja9RcGoMdncZ6T49FCUl2lN38JtCJ+3WgIDBv0AuY4WChU5PmtJmOCTlN6FZTFKQ==",
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.10.0.tgz",
+      "integrity": "sha512-Cu96Sd2By9mCNTx2iyKOmq10v22jUVQv0lQnlGNy16oE9589yE+QADPbrMGCkA51cKZSg3Pu/aTJVTGfL/qjUA==",
       "dev": true,
       "engines": {
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.0.tgz",
-      "integrity": "sha512-Lj7DECXqIVCqnqjjHMPna4vn6GJcMgul/wuS0je9OZ9gsL0zzDpKPVtcG1HaDVc+9y+qgXneTeUMbCqXJNpH1A==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.0.2.tgz",
+      "integrity": "sha512-wV19ZEGEMAC1eHgrS7UQPqsdEiCIbTKTasEfcXAigzoXICcqZSjBZEHlZwNVvKg6UBCjSlos84XiLqsRJnIcIg==",
       "dev": true,
       "dependencies": {
         "ajv": "^6.12.4",
         "debug": "^4.3.2",
-        "espree": "^9.6.0",
-        "globals": "^13.19.0",
+        "espree": "^10.0.1",
+        "globals": "^14.0.0",
         "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
         "js-yaml": "^4.1.0",
@@ -68,29 +68,29 @@
         "strip-json-comments": "^3.1.1"
       },
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/@eslint/js": {
-      "version": "8.44.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.44.0.tgz",
-      "integrity": "sha512-Ag+9YM4ocKQx9AarydN0KY2j0ErMHNIocPDrVo8zAE44xLTjEtz81OdR68/cydGtk6m6jDb5Za3r2useMzYmSw==",
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.1.1.tgz",
+      "integrity": "sha512-5WoDz3Y19Bg2BnErkZTp0en+c/i9PvgFS7MBe1+m60HjFr0hrphlAGp4yzI7pxpt4xShln4ZyYp4neJm8hmOkQ==",
       "dev": true,
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
-      "version": "0.11.10",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.10.tgz",
-      "integrity": "sha512-KVVjQmNUepDVGXNuoRRdmmEjruj0KfiGSbS8LVc12LMsWDQzRXJ0qdhN8L8uUigKpfEHRhlaQFY0ib1tnUbNeQ==",
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
+      "integrity": "sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==",
       "dev": true,
       "dependencies": {
-        "@humanwhocodes/object-schema": "^1.2.1",
-        "debug": "^4.1.1",
+        "@humanwhocodes/object-schema": "^2.0.3",
+        "debug": "^4.3.1",
         "minimatch": "^3.0.5"
       },
       "engines": {
@@ -111,10 +111,23 @@
       }
     },
     "node_modules/@humanwhocodes/object-schema": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
-      "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz",
+      "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
       "dev": true
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.2.3.tgz",
+      "integrity": "sha512-X38nUbachlb01YMlvPFojKoiXq+LzZvuSce70KPMPdeM1Rj03k4dR7lDslhbqXn3Ang4EU3+EAmwEAsbrjHW3g==",
+      "dev": true,
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -152,9 +165,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.10.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
-      "integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==",
+      "version": "8.11.3",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
+      "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
       "dev": true,
       "bin": {
         "acorn": "bin/acorn"
@@ -320,18 +333,6 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true
     },
-    "node_modules/doctrine": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
-      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
-      "dev": true,
-      "dependencies": {
-        "esutils": "^2.0.2"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
@@ -345,41 +346,37 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.44.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.44.0.tgz",
-      "integrity": "sha512-0wpHoUbDUHgNCyvFB5aXLiQVfK9B0at6gUvzy83k4kAsQ/u769TQDX6iKC+aO4upIHO9WSaA3QoXYQDHbNwf1A==",
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.1.1.tgz",
+      "integrity": "sha512-b4cRQ0BeZcSEzPpY2PjFY70VbO32K7BStTGtBsnIGdTSEEQzBi8hPBcGQmTG2zUvFr9uLe0TK42bw8YszuHEqg==",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
-        "@eslint-community/regexpp": "^4.4.0",
-        "@eslint/eslintrc": "^2.1.0",
-        "@eslint/js": "8.44.0",
-        "@humanwhocodes/config-array": "^0.11.10",
+        "@eslint-community/regexpp": "^4.6.1",
+        "@eslint/eslintrc": "^3.0.2",
+        "@eslint/js": "9.1.1",
+        "@humanwhocodes/config-array": "^0.13.0",
         "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.2.3",
         "@nodelib/fs.walk": "^1.2.8",
-        "ajv": "^6.10.0",
+        "ajv": "^6.12.4",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.2",
         "debug": "^4.3.2",
-        "doctrine": "^3.0.0",
         "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^7.2.0",
-        "eslint-visitor-keys": "^3.4.1",
-        "espree": "^9.6.0",
+        "eslint-scope": "^8.0.1",
+        "eslint-visitor-keys": "^4.0.0",
+        "espree": "^10.0.1",
         "esquery": "^1.4.2",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
-        "file-entry-cache": "^6.0.1",
+        "file-entry-cache": "^8.0.0",
         "find-up": "^5.0.0",
         "glob-parent": "^6.0.2",
-        "globals": "^13.19.0",
-        "graphemer": "^1.4.0",
         "ignore": "^5.2.0",
-        "import-fresh": "^3.0.0",
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
         "is-path-inside": "^3.0.3",
-        "js-yaml": "^4.1.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "levn": "^0.4.1",
         "lodash.merge": "^4.6.2",
@@ -387,30 +384,29 @@
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.3",
         "strip-ansi": "^6.0.1",
-        "strip-json-comments": "^3.1.0",
         "text-table": "^0.2.0"
       },
       "bin": {
         "eslint": "bin/eslint.js"
       },
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/eslint-scope": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.0.tgz",
-      "integrity": "sha512-DYj5deGlHBfMt15J7rdtyKNq/Nqlv5KfU4iodrQ019XESsRnwXH9KAE0y3cwtUHDo2ob7CypAnCqefh6vioWRw==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.0.1.tgz",
+      "integrity": "sha512-pL8XjgP4ZOmmwfFE8mEhSxA7ZY4C+LWyqjQ3o4yWkkmD0qcMT9kkW3zWHOczhWcjTSgqycYAgwSlXvZltv65og==",
       "dev": true,
       "dependencies": {
         "esrecurse": "^4.3.0",
         "estraverse": "^5.2.0"
       },
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
@@ -428,18 +424,42 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/eslint/node_modules/eslint-visitor-keys": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.0.0.tgz",
+      "integrity": "sha512-OtIRv/2GyiF6o/d8K7MYKKbXrOUBIK6SfkIRM4Z0dY3w+LiQ0vy3F57m0Z71bjbyeiWFiHJ8brqnmE6H6/jEuw==",
+      "dev": true,
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
     "node_modules/espree": {
-      "version": "9.6.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.0.tgz",
-      "integrity": "sha512-1FH/IiruXZ84tpUlm0aCUEwMl2Ho5ilqVh0VvQXw+byAz/4SAciyHLlfmL5WYqsvD38oymdUwBss0LtK8m4s/A==",
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.0.1.tgz",
+      "integrity": "sha512-MWkrWZbJsL2UwnjxTX3gG8FneachS/Mwg7tdGXce011sJd5b0JG54vat5KHnfSBODZ3Wvzd2WnjxyzsRoVv+ww==",
       "dev": true,
       "dependencies": {
-        "acorn": "^8.9.0",
+        "acorn": "^8.11.3",
         "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^3.4.1"
+        "eslint-visitor-keys": "^4.0.0"
       },
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/espree/node_modules/eslint-visitor-keys": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.0.0.tgz",
+      "integrity": "sha512-OtIRv/2GyiF6o/d8K7MYKKbXrOUBIK6SfkIRM4Z0dY3w+LiQ0vy3F57m0Z71bjbyeiWFiHJ8brqnmE6H6/jEuw==",
+      "dev": true,
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
@@ -515,15 +535,15 @@
       }
     },
     "node_modules/file-entry-cache": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
-      "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
       "dev": true,
       "dependencies": {
-        "flat-cache": "^3.0.4"
+        "flat-cache": "^4.0.0"
       },
       "engines": {
-        "node": "^10.12.0 || >=12.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/find-up": {
@@ -543,49 +563,23 @@
       }
     },
     "node_modules/flat-cache": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
-      "integrity": "sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
       "dev": true,
       "dependencies": {
-        "flatted": "^3.1.0",
-        "rimraf": "^3.0.2"
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
       },
       "engines": {
-        "node": "^10.12.0 || >=12.0.0"
+        "node": ">=16"
       }
     },
     "node_modules/flatted": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz",
-      "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.1.tgz",
+      "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
       "dev": true
-    },
-    "node_modules/fs.realpath": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-      "dev": true
-    },
-    "node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "dev": true,
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
     },
     "node_modules/glob-parent": {
       "version": "6.0.2",
@@ -600,25 +594,16 @@
       }
     },
     "node_modules/globals": {
-      "version": "13.20.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.20.0.tgz",
-      "integrity": "sha512-Qg5QtVkCy/kv3FUSlu4ukeZDVf9ee0iXLAUYX13gbR17bnejFTzr4iS9bY7kwCf1NztRNm1t91fjOiyx4CSwPQ==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
       "dev": true,
-      "dependencies": {
-        "type-fest": "^0.20.2"
-      },
       "engines": {
-        "node": ">=8"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/graphemer": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
-      "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
-      "dev": true
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
@@ -630,9 +615,9 @@
       }
     },
     "node_modules/ignore": {
-      "version": "5.2.4",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
-      "integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.1.tgz",
+      "integrity": "sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw==",
       "dev": true,
       "engines": {
         "node": ">= 4"
@@ -662,22 +647,6 @@
       "engines": {
         "node": ">=0.8.19"
       }
-    },
-    "node_modules/inflight": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
-      "dev": true,
-      "dependencies": {
-        "once": "^1.3.0",
-        "wrappy": "1"
-      }
-    },
-    "node_modules/inherits": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
@@ -727,6 +696,12 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true
+    },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -738,6 +713,15 @@
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
     },
     "node_modules/levn": {
       "version": "0.4.1",
@@ -796,15 +780,6 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
-    },
-    "node_modules/once": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dev": true,
-      "dependencies": {
-        "wrappy": "1"
-      }
     },
     "node_modules/optionator": {
       "version": "0.9.3",
@@ -874,15 +849,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/path-is-absolute": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
@@ -902,9 +868,9 @@
       }
     },
     "node_modules/punycode": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
-      "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "dev": true,
       "engines": {
         "node": ">=6"
@@ -947,21 +913,6 @@
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/rimraf": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "dev": true,
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/run-parallel": {
@@ -1062,18 +1013,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/type-fest": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -1097,12 +1036,6 @@
       "engines": {
         "node": ">= 8"
       }
-    },
-    "node_modules/wrappy": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   ],
   "main": "index.js",
   "scripts": {
-    "lint": "eslint --config .eslintrc.root *.js",
+    "lint": "eslint --config eslint.root.js *.js",
     "test:examples": "./bin/examples.sh",
     "test:install": "./bin/test.sh"
   },
@@ -36,6 +36,6 @@
     "eslint": "^8.44.0"
   },
   "peerDependencies": {
-    "eslint": "^6 || ^7 || ^8 || ^9"
+    "eslint": "^8.27 || ^9"
   }
 }

--- a/package.json
+++ b/package.json
@@ -36,6 +36,6 @@
     "eslint": "^8.44.0"
   },
   "peerDependencies": {
-    "eslint": "^6 || ^7 || ^8"
+    "eslint": "^6 || ^7 || ^8 || ^9"
   }
 }

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "homepage": "https://github.com/codeyourfuture/eslint-config-standard#readme",
   "funding": "https://github.com/sponsors/CodeYourFuture",
   "devDependencies": {
-    "eslint": "^8.44.0"
+    "eslint": "^9.1.1"
   },
   "peerDependencies": {
     "eslint": "^8.27 || ^9"


### PR DESCRIPTION
[ESLint v9](https://eslint.org/blog/2024/04/eslint-v9.0.0-released/) now defaults to the new "flat config" approach. This PR updates the standard and lax configurations to simultaneously support both `eslint.config.js` (flat) and `.eslintrc` (deprecated) options.

- It drops support for ESLint < [8.27](https://eslint.org/blog/2022/11/eslint-v8.27.0-released/) (released November 2022), as `@eslint/js` recommended includes two rules (`no-empty-static-block` and `no-new-native-nonconstructor`) introduced here. 
- Node.js v16 is still supported, but only with ESLint v8, as ESLint v9 requires at least Node.js v18.18.

### Links

- Fixes #16